### PR TITLE
Fixes #43 - remove the Auto and Manual labels from the site

### DIFF
--- a/ladder/apps/accounts/templates/accounts/admin/user_detail.html
+++ b/ladder/apps/accounts/templates/accounts/admin/user_detail.html
@@ -39,7 +39,6 @@
         <thead>
             <tr>
                 <th>#</th>
-                <th>Auto/Manual</th>
                 <th>Status</th>
                 <th>Actions</th>
             </tr>
@@ -50,7 +49,6 @@
                     <td>
                         <a href="{% url 'admin:offer-detail' pk=ticket_offer.pk %}">{{ ticket_offer.pk }}</a>
                     </td>
-                    <td><span class="badge">{{ ticket_offer.is_automatch|yesno:'Automatch,Manual' }}</td>
                     <td>{{ ticket_offer.get_status_display }}</td>
                     <td>
                         <a href="{% url 'admin:offer-detail' pk=ticket_offer.pk %}">Details</a>

--- a/ladder/apps/exchange/templates/exchange/admin/partials/match_table.html
+++ b/ladder/apps/exchange/templates/exchange/admin/partials/match_table.html
@@ -4,7 +4,6 @@
             <th>#</th>
             <th>Offering User</th>
             <th>Requesting User</th>
-            <th>Auto/Manual</th>
             <th>Status</th>
             <th>Created</th>
             <th>Actions</th>
@@ -21,11 +20,6 @@
                 </td>
                 <td>
                     <a href="{% url 'admin:user-detail' pk=ticket_match.ticket_request.user.pk %}">{{ ticket_match.ticket_request.user }}</a>
-                </td>
-                <td>
-                    <span class="badge">
-                        {{ ticket_match.ticket_offer.is_automatch|yesno:'Automatch,Manual' }}
-                    </span>
                 </td>
                 <td>{{ ticket_match.get_status_display }}</td>
                 <td>{{ ticket_match.created_at }}</td>

--- a/ladder/apps/exchange/templates/exchange/admin/partials/offer_table.html
+++ b/ladder/apps/exchange/templates/exchange/admin/partials/offer_table.html
@@ -3,7 +3,6 @@
         <tr>
             <th>#</th>
             <th>Offering User</th>
-            <th>Auto/Manual</th>
             <th>Status</th>
             <th>Created At</th>
             <th>Actions</th>
@@ -16,7 +15,6 @@
                     <a href="{% url 'admin:offer-detail' pk=ticket_offer.pk %}">{{ ticket_offer.pk }}</a>
                 </td>
                 <td>{{ ticket_offer.user }}</td>
-                <td><span class="badge">{{ ticket_offer.is_automatch|yesno:'Automatch,Manual' }}</td>
                 <td>{{ ticket_offer.get_status_display }}</td>
                 <td>{{ ticket_offer.created_at }}</td>
                 <td>


### PR DESCRIPTION
The `Auto` and `Manual` labels no longer make sense and should be removed.