### PR TITLE
fix bug with match expiration

### DIFF
--- a/ladder/apps/exchange/forms.py
+++ b/ladder/apps/exchange/forms.py
@@ -18,7 +18,6 @@ class TicketOfferForm(BetterModelForm):
     class Meta:
         model = TicketOffer
         fields = (
-            'is_automatch',
             'ticket_code',
         )
 

--- a/ladder/apps/exchange/migrations/0008_remove_ticketoffer_is_automatch.py
+++ b/ladder/apps/exchange/migrations/0008_remove_ticketoffer_is_automatch.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('exchange', '0007_remove_ticketmatch_is_terminated'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='ticketoffer',
+            name='is_automatch',
+        ),
+    ]

--- a/ladder/apps/exchange/templates/exchange/offer_create.html
+++ b/ladder/apps/exchange/templates/exchange/offer_create.html
@@ -36,7 +36,6 @@
         <div class="col-md-6">
             <form id="auto-match" action="." method="post" class="jumbotron">
                 {% csrf_token %}
-                <input type="hidden" name="is_automatch" value="1">
                 <input type="hidden" name="ticket_code">
                 <p class="text-info">Just give my ticket to the first person in line.</p>
                 <button class="btn btn-large btn-block btn-info" type="submit">Go</button>

--- a/tests/exchange/test_expired_match_is_correctly_matched.py
+++ b/tests/exchange/test_expired_match_is_correctly_matched.py
@@ -1,0 +1,50 @@
+from django.core.urlresolvers import reverse
+from django.core import mail
+
+from rest_framework import status
+
+
+def test_expired_match_offer_is_correctly_matched(factories, user_client, models):
+    """
+    Test the situation where a match expires, leaving the ticket offer
+    up-for-grabs.  This offer should be matched with the next person in line as
+    opposed to the next person who requests a ticket.
+    """
+    # this request *should* be matched next
+    pending_request = factories.TicketRequestFactory()
+    assert not pending_request.matches.exists()
+
+    match = factories.ExpiredTicketMatchFactory()
+
+    # sanity checks
+    assert match.is_expired
+    assert match in models.TicketMatch.objects.is_expired()
+
+    request = match.ticket_request
+    assert not request.is_active
+    assert request not in models.TicketRequest.objects.is_active()
+
+    offer = match.ticket_offer
+    assert offer.is_active
+    assert offer in models.TicketOffer.objects.is_active()
+
+    # Now create a new request
+    create_request_url = reverse('request-create')
+
+    user = user_client.user
+    assert not user.ticket_requests.exists()
+
+    response = user_client.post(create_request_url, {
+        'message': 'A request message',
+    })
+    assert response.status_code == status.HTTP_302_FOUND
+
+    # This new request should not be matched with an offer.
+    created_request = user.ticket_requests.get()
+    assert created_request.is_active
+
+    # The pending request should have been consumed.
+    assert offer.is_reserved
+    assert pending_request.is_reserved
+
+    assert len(mail.outbox) == 1

--- a/tests/exchange/test_ticket_match_creation_api.py
+++ b/tests/exchange/test_ticket_match_creation_api.py
@@ -1,0 +1,78 @@
+import pytest
+
+from django.core import mail
+
+
+def test_with_no_specified_offer_or_request(factories, models):
+    request = factories.TicketRequestFactory()
+    offer = factories.TicketOfferFactory()
+
+    match = models.TicketMatch.objects.create_match()
+
+    assert match.ticket_request == request
+    assert match.ticket_offer == offer
+    assert not mail.outbox
+
+
+def test_with_specified_ticket_request(factories, models):
+    first_request = factories.TicketRequestFactory()
+    second_request = factories.TicketRequestFactory()
+    offer = factories.TicketOfferFactory()
+
+    match = models.TicketMatch.objects.create_match(ticket_request=second_request)
+
+    assert match.ticket_request == second_request
+    assert match.ticket_offer == offer
+    assert not mail.outbox
+
+
+def test_with_specified_ticket_offer(factories, models):
+    request = factories.TicketRequestFactory()
+    first_offer = factories.TicketOfferFactory()
+    second_offer = factories.TicketOfferFactory()
+
+    match = models.TicketMatch.objects.create_match(ticket_offer=second_offer)
+
+    assert match.ticket_request == request
+    assert match.ticket_offer == second_offer
+    assert not mail.outbox
+
+
+def test_with_no_active_request(factories, models):
+    factories.TicketRequestFactory(is_cancelled=True)
+    factories.TicketRequestFactory(is_terminated=True)
+    factories.AcceptedTicketMatchFactory()
+
+    factories.TicketOfferFactory()
+
+    with pytest.raises(models.TicketRequest.DoesNotExist):
+        models.TicketMatch.objects.create_match()
+    assert not mail.outbox
+
+
+def test_with_no_active_offer(factories, models):
+    factories.TicketOfferFactory(is_cancelled=True)
+    factories.TicketOfferFactory(is_terminated=True)
+    factories.AcceptedTicketMatchFactory()
+
+    factories.TicketRequestFactory()
+
+    with pytest.raises(models.TicketOffer.DoesNotExist):
+        models.TicketMatch.objects.create_match()
+    assert not mail.outbox
+
+
+def test_fail_silently(models):
+    models.TicketMatch.objects.create_match(fail_silently=True)
+    assert not mail.outbox
+
+
+def test_send_email_option(factories, models):
+    request = factories.TicketRequestFactory()
+    offer = factories.TicketOfferFactory()
+
+    match = models.TicketMatch.objects.create_match(send_confirmation_email=True)
+
+    assert match.ticket_request == request
+    assert match.ticket_offer == offer
+    assert len(mail.outbox) == 1


### PR DESCRIPTION
Fix a bug when a match has expired.  The ticket offer involved should be given to the first person in line, but instead, it was being given to the next person who requested a ticket.  Fixed now with tests to cover it.